### PR TITLE
Fix for issue "Wrong delta"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ web_modules/
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode
 
 # yarn v2
 .yarn/cache

--- a/src/agents/openai/OpenAIAgent.ts
+++ b/src/agents/openai/OpenAIAgent.ts
@@ -102,8 +102,9 @@ export class OpenAIAgent implements AIAgent {
       message_id: channelMessage.id,
     });
 
-    const run = this.openai.beta.threads.runs.stream(this.openAiThread.id, {
+    const run = await this.openai.beta.threads.runs.create(this.openAiThread.id, {
       assistant_id: this.assistant.id,
+	  stream: true
     });
 
     const handler = new OpenAIResponseHandler(

--- a/src/agents/openai/OpenAIResponseHandler.ts
+++ b/src/agents/openai/OpenAIResponseHandler.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import OpenAI from 'openai';
 import type { AssistantStream } from 'openai/lib/AssistantStream';
+import { Stream } from 'openai/streaming';
 import type { Channel, MessageResponse, StreamChat } from 'stream-chat';
 
 export class OpenAIResponseHandler {
@@ -11,7 +12,7 @@ export class OpenAIResponseHandler {
   constructor(
     private readonly openai: OpenAI,
     private readonly openAiThread: OpenAI.Beta.Threads.Thread,
-    private readonly assistantStream: AssistantStream,
+	private readonly assistantStream: AssistantStream | Stream<OpenAI.Beta.Assistants.AssistantStreamEvent>,
     private readonly chatClient: StreamChat,
     private readonly channel: Channel,
     private readonly message: MessageResponse,


### PR DESCRIPTION
Tested with node v22.14.0 (LTS)
Fixes issue #4 

Before fix:

```
INPUT IN CHAT: Hello

DELTA **Hello! How can I assist you today <- should be "Hello"**
DELTA !
DELTA  How
DELTA  can
DELTA  I
DELTA  assist
DELTA  you
DELTA  today
DELTA ?

RESULT IN CHAT: Hello! How can I assist you tod**ay! How** can I assist you today?

INPUT IN CHAT: How can you help me?

DELTA **I can assist you with <- should be "I"**
DELTA  can
DELTA  assist
DELTA  you
DELTA  with
DELTA  a
DELTA  wide
DELTA  range
DELTA  of
DELTA  tasks
...

RESULT IN CHAT: I can assist you **with can as**sist you with a wide range of tasks...

```
After fix:

```
INPUT IN CHAT: Hello

DELTA Hi
DELTA  there
DELTA !
DELTA  How
DELTA  can
DELTA  I
DELTA  assist
DELTA  you
DELTA  today
DELTA ?

RESULT IN CHAT: Hi there! How can I assist you today?

```